### PR TITLE
Update screen less often

### DIFF
--- a/source/main.lua
+++ b/source/main.lua
@@ -166,6 +166,9 @@ local textProgress = 0
 -- Whether the options menu is visible and active
 local menuActive = false
 
+local lastOffset = -1000
+local forceRedraw = false
+
 -- Menu
 -- The views for each option
 local optionViews = {}
@@ -425,6 +428,7 @@ function initLibrary()
 
 	-- Reset variables
 	offset = 0
+	lastOffset = -1000
 	directionHeld = 0
 
 	fallingBookProgress = 0 - DEVICE_HEIGHT * 4.75
@@ -485,6 +489,8 @@ function reloadReader()
 
 	-- Reset the crank position
 	offset = 0
+	-- Force the reader to redraw next frame
+	lastOffset = -1000;
 
 	-- Update the font
 	graphics.setFont(FONTS[readerFontId].font)
@@ -937,7 +943,6 @@ function playdate.update()
 		end
 		drawLibrary()
 	elseif scene == READER then
-		drawText()
 		-- Update offset when the D-pad is held
 		offset = offset + directionHeld * BTN_SCROLL_SPEED
 		if menuActive or not playScrollSound then
@@ -951,6 +956,11 @@ function playdate.update()
 				-- Update the sound
 				sound:setVolume(vol)
 			end
+		end
+		if offset ~= lastOffset or forceRedraw then
+			drawText()
+			lastOffset = offset
+			forceRedraw = false
 		end
 	end
 	if menuActive then
@@ -1403,6 +1413,7 @@ function playdate.AButtonDown()
 		else
 			saveState()
 			menuActive = false
+			forceRedraw = true
 		end
 	end
 end

--- a/source/main.lua
+++ b/source/main.lua
@@ -696,12 +696,14 @@ local drawText = function ()
 			local lineRange = ceil((drawOffset + 2 * lineHeight) / lineHeight)
 			-- lineRange = 1
 			removeLines(prependLines(lineRange), true)
+			forceRedraw = true
 		end
 		-- Detect end of text
 		if drawOffset + numOfLines * lineHeight < DEVICE_HEIGHT then
 			local lineRange = ceil((DEVICE_HEIGHT - (drawOffset + numOfLines * lineHeight)) / lineHeight)
 			-- lineRange = 1
 			removeLines(appendLines(lineRange), false)
+			forceRedraw = true
 		end
 	end
 	if progressIndicator == 2 then
@@ -958,9 +960,9 @@ function playdate.update()
 			end
 		end
 		if offset ~= lastOffset or forceRedraw then
+			forceRedraw = false
 			drawText()
 			lastOffset = offset
-			forceRedraw = false
 		end
 	end
 	if menuActive then


### PR DESCRIPTION
From [Designing for Playdate](https://help.play.date/developer/designing-for-playdate/#performance):
> you don’t need to redraw the entire content of the screen on each update, just the areas which have changed. This can be a significant performance and battery life gain for non-action games where display elements move less frequently.

This pull request updates the reader screen to only redraw on frames where you scrolled rather than every frame.

As a result of my implementation, the candle's flame no longer animates when the screen is idle. I haven't tried to solve this, the best method would be to only redraw the portion of the screen with the candle's flame only on the frames where it changes, but I don't personally use the candle so I've just ignored this. :sweat_smile: 