### PR TITLE
Add "Reading Orientation" option

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "midouest.playdate-debug",
+        "orta.playdate"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "playdate",
+            "request": "launch",
+            "name": "Playdate: Debug",
+            "preLaunchTask": "${defaultBuildTask}",
+            "source": "${workspaceRoot}/source",
+            "output": "${workspaceRoot}/build/PlayBook.pdx",
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "Lua.runtime.version": "Lua 5.4",
+  "Lua.diagnostics.disable": [
+    "undefined-global",
+    "lowercase-global",
+    "undefined-field",
+    "need-check-nil",
+    "deprecated",
+    "param-type-mismatch",
+    "duplicate-set-field",
+    "inject-field",
+    "cast-local-type",
+    "trailing-space"
+  ],
+  "Lua.diagnostics.globals": ["playdate", "import"],
+  "Lua.runtime.nonstandardSymbol": ["+=", "-=", "*=", "/=", "//=", "%=", "<<=", ">>=", "&=", "|=", "^="],
+  "Lua.workspace.library": ["~/code/playdate-luacats"],
+  "Lua.workspace.preloadFileSize": 1000,
+  "playdate-debug.sourcePath": "source",
+  "playdate-debug.outputPath": "./build/",
+  "playdate-debug.productName": "PlayBook"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "command": "VER=\"$(grep -Po '(?<=buildNumber=)(.*)$' source/pdxinfo)\"; sed -i \"s/buildNumber=$VER/buildNumber=$((1+VER))/\" source/pdxinfo",
+            "label": "Playdate: Increment Build Number"
+        },
+        {
+            "type": "pdc",
+            "problemMatcher": ["$pdc-lua", "$pdc-external"],
+            "label": "Playdate: Build"
+        },
+        {
+            "type": "playdate-simulator",
+            "problemMatcher": ["$pdc-external"],
+            "label": "Playdate: Run"
+        },
+        {
+            "type": "shell",
+            "command": "[ -f build/PlayBook.pdx.zip ] && rm build/PlayBook.pdx.zip; zip -r build/PlayBook.pdx.zip build/PlayBook.pdx",
+            "label": "Playdate: Zip up"
+        },
+        {
+            "type": "shell",
+            "command": "[ -d $PLAYDATE_SDK_PATH/Disk/Games/PlayBook.pdx ] && rm -rf $PLAYDATE_SDK_PATH/Disk/Games/PlayBook.pdx; cp -r build/PlayBook.pdx $PLAYDATE_SDK_PATH/Disk/Games/PlayBook.pdx",
+            "label": "Playdate: Copy"
+        },
+        {
+            "label": "Playdate: Build and Run",
+            "dependsOn": ["Playdate: Increment Build Number", "Playdate: Build", "Playdate: Copy", "Playdate: Run"],
+            "dependsOrder": "sequence",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/source/main.lua
+++ b/source/main.lua
@@ -992,6 +992,7 @@ function playdate.update()
 		end
 		drawLibrary()
 	elseif scene == READER then
+		drawText()
 		-- Update offset when the D-pad is held
 		offset = offset + directionHeld * BTN_SCROLL_SPEED * delta
 		if menuActive or not playScrollSound then

--- a/source/main.lua
+++ b/source/main.lua
@@ -27,7 +27,7 @@ local MAX_VOLUME <const> = 0.025
 -- The speed of scrolling via the crank
 local CRANK_SCROLL_SPEED <const> = 1.2
 -- The speed of scrolling via the D-pad
-local BTN_SCROLL_SPEED <const> = 6
+local BTN_SCROLL_SPEED <const> = 300
 local MARGIN_WITH_BORDER <const> = 22
 local MARGIN_WITHOUT_BORDER <const> = 6
 local BOOK_SEPARATION <const> = 42
@@ -732,7 +732,30 @@ local drawText = function ()
 		drawScrollbar()
 	end
 	graphics.popContext()
-	img:rotatedImage(rotationDegrees()):draw(0, 0)
+	if not isHorizontal() then img = rotateImg90(img) end
+	if readingOrientation <= 2 then
+		img:draw(0, 0)
+	else
+		img:drawRotated(DEVICE_WIDTH / 2, DEVICE_HEIGHT / 2, 180)
+	end
+end
+
+-- rotating an entire image 90 degrees using the default image rotation functions is super slow on rev b, so split the image into chunks then rotate them all
+-- this doesnt optimise it enough so that the app runs at full 50fps speed, i'm sure there's a way to do so though
+function rotateImg90(img)
+	local newImg = graphics.image.new(img.height, img.width)
+	for x = 0, newImg.height / 200 do
+		for y = 0, newImg.width / 120 do
+			local segment = graphics.image.new(120, 200)
+			graphics.pushContext(segment)
+			img:draw(0, 0, graphics.kImageUnflipped, playdate.geometry.rect.new(segment.width * x, segment.height * y, segment.width, segment.height))
+			graphics.popContext()
+			graphics.pushContext(newImg)
+			segment:drawRotated(newImg.width - y * segment.height - segment.height / 2, x * segment.width + segment.width / 2, 90)
+			graphics.popContext()
+		end
+	end
+	return newImg
 end
 
 -- Draw an individual book
@@ -907,6 +930,8 @@ end
 
 -- Update loop
 function playdate.update()
+	local delta = playdate.getElapsedTime()
+	playdate.resetElapsedTime()
 	if scene == LIBRARY then
 		local folderSwitched = false
 		if playdate.buttonJustPressed(playdate.kButtonLeft) then
@@ -967,7 +992,6 @@ function playdate.update()
 		end
 		drawLibrary()
 	elseif scene == READER then
-		drawText()
 		-- Update offset when the D-pad is held
 		offset = offset + directionHeld * BTN_SCROLL_SPEED
 		if menuActive or not playScrollSound then
@@ -1116,8 +1140,6 @@ end
 -- Add the given number of lines to the list
 -- Note that if there are no more lines available, less than the given number of lines will be returned
 function addLines(additionalLines, append, startChar)
-	-- Keep track of time taken
-	playdate.resetElapsedTime()
 	if text == nil then
 		print("Error: text is nil")
 		return

--- a/source/main.lua
+++ b/source/main.lua
@@ -80,7 +80,12 @@ local DEFAULT_BOOKS <const> = {
 	"Frankenstein.txt",
 	"The Great Gatsby.txt",
 }
+-- 
 local readingOrientation = 1
+function isHorizontal() return readingOrientation == 1 or readingOrientation == 4 end
+function rotationDegrees() if readingOrientation == 1 then return 0 elseif readingOrientation == 2 then return 90 elseif readingOrientation == 3 then return 270 else return 180 end end
+function height() return isHorizontal() and DEVICE_HEIGHT or DEVICE_WIDTH end
+function width() return isHorizontal() and DEVICE_WIDTH or DEVICE_HEIGHT end
 
 -- Shared
 -- The current scene being displayed
@@ -308,6 +313,9 @@ local MENU_OPTIONS <const> = {
 		end,
 		callback = function (index)
 			readingOrientation = index
+			if scene == READER then
+				reloadReader()
+			end
 		end
 	},
 }
@@ -620,8 +628,8 @@ end
 
 -- Draw a candle to the side of the text to indicate progress
 local drawCandle = function ()
-	local TOP = textProgress * (DEVICE_HEIGHT - candleTop.height - 10 - candleHolder.height) + 4
-	local LEFT = DEVICE_WIDTH - 1 - candleSection.width
+	local TOP = textProgress * (height() - candleTop.height - 10 - candleHolder.height) + 4
+	local LEFT = width() - 1 - candleSection.width
 	-- Draw the top of the candle
 	candleTop:draw(LEFT, TOP)
 	-- Draw the flame flickering
@@ -639,21 +647,21 @@ local drawCandle = function ()
 	end
 	flame:draw(LEFT, TOP)
 	-- Draw the candle length
-	local sections = floor((DEVICE_HEIGHT - TOP - candleTop.height) / candleSection.height) + 1
+	local sections = floor((height() - TOP - candleTop.height) / candleSection.height) + 1
 	for i = 1, sections do
 		candleSection:draw(LEFT, TOP + candleTop.height + (i - 1) * candleSection.height)
 	end
 	-- Draw the holder
-	candleHolder:draw(LEFT, DEVICE_HEIGHT - candleHolder.height)
+	candleHolder:draw(LEFT, height() - candleHolder.height)
 	-- Draw the drips
-	local bottom = DEVICE_HEIGHT - candleDripLeft.height + 4 - candleHolder.height
+	local bottom = height() - candleDripLeft.height + 4 - candleHolder.height
 	candleDripLeft:draw(LEFT, min(bottom, TOP + 40 + textProgress * 115))
 	candleDripRight:draw(LEFT + candleSection.width - candleDripRight.width, min(bottom, TOP + 90 + textProgress * 20))
 end
 
 local drawScrollbar = function ()
 	local VERT_MARGIN = 2
-	local LEFT = DEVICE_WIDTH - 2 - scrollbarSection.width
+	local LEFT = width() - 2 - scrollbarSection.width
 	-- Draw the top arrow
 	scrollbarButton:draw(LEFT, VERT_MARGIN)
 	scrollbarArrow:draw(LEFT + 2, VERT_MARGIN + 2)
@@ -662,8 +670,8 @@ local drawScrollbar = function ()
 		scrollbarSection:draw(LEFT, VERT_MARGIN + scrollbarButton.height + (i - 1) * scrollbarSection.height)
 	end
 	-- Draw the bottom arrow
-	scrollbarButton:draw(LEFT, DEVICE_HEIGHT - VERT_MARGIN - scrollbarButton.height)
-	scrollbarArrow:draw(LEFT + 2, DEVICE_HEIGHT - VERT_MARGIN - scrollbarButton.height + 3, graphics.kImageFlippedY)
+	scrollbarButton:draw(LEFT, height() - VERT_MARGIN - scrollbarButton.height)
+	scrollbarArrow:draw(LEFT + 2, height() - VERT_MARGIN - scrollbarButton.height + 3, graphics.kImageFlippedY)
 	-- Draw the slider
 	local progress = textProgress
 	if progress <= 0.01 then
@@ -671,7 +679,7 @@ local drawScrollbar = function ()
 	elseif progress >= 0.99 then
 		progress = 1
 	end
-	local sliderY = VERT_MARGIN + scrollbarButton.height + floor(progress * (DEVICE_HEIGHT - VERT_MARGIN * 2 - scrollbarButton.height * 2 - scrollbarSlider.height))
+	local sliderY = VERT_MARGIN + scrollbarButton.height + floor(progress * (height() - VERT_MARGIN * 2 - scrollbarButton.height * 2 - scrollbarSlider.height))
 	scrollbarSlider:draw(LEFT + 1, sliderY)
 end
 
@@ -681,11 +689,13 @@ local drawText = function ()
 	graphics.setFont(FONTS[readerFontId].font)
 	-- Draw offset for debugging
 	-- graphics.drawText(playdate.getCrankPosition(), leftMargin, offset)
+	local img = graphics.image.new(width(), height())
+	graphics.pushContext(img)
 	if #lines > 0 then
 		-- Calculate where to begin drawing lines
 		local drawOffset = floor(offset) + emptyLinesAbove * lineHeight
 		local numOfLines = #lines
-		local lineEnd = min(ceil((DEVICE_HEIGHT - drawOffset) / lineHeight), numOfLines)
+		local lineEnd = min(ceil((height() - drawOffset) / lineHeight), numOfLines)
 		local topLineStart = nil
 		local topLineStop = nil
 		for i = 1, lineEnd do
@@ -710,8 +720,8 @@ local drawText = function ()
 			removeLines(prependLines(lineRange), true)
 		end
 		-- Detect end of text
-		if drawOffset + numOfLines * lineHeight < DEVICE_HEIGHT then
-			local lineRange = ceil((DEVICE_HEIGHT - (drawOffset + numOfLines * lineHeight)) / lineHeight)
+		if drawOffset + numOfLines * lineHeight < height() then
+			local lineRange = ceil((height() - (drawOffset + numOfLines * lineHeight)) / lineHeight)
 			-- lineRange = 1
 			removeLines(appendLines(lineRange), false)
 		end
@@ -721,6 +731,8 @@ local drawText = function ()
 	elseif progressIndicator == 3 then
 		drawScrollbar()
 	end
+	graphics.popContext()
+	img:rotatedImage(rotationDegrees()):draw(0, 0)
 end
 
 -- Draw an individual book
@@ -1166,7 +1178,7 @@ function addLines(additionalLines, append, startChar)
 	end
 
 	-- The max width in pixels that a line can be
-	local MAX_WIDTH <const> = DEVICE_WIDTH - leftMargin - rightMargin
+	local MAX_WIDTH <const> = width() - leftMargin - rightMargin
 	-- The text of the current line as it is processed
 	local currentLine = ""
 	-- The index of the first character of the current line

--- a/source/main.lua
+++ b/source/main.lua
@@ -666,7 +666,7 @@ local drawScrollbar = function ()
 	scrollbarButton:draw(LEFT, VERT_MARGIN)
 	scrollbarArrow:draw(LEFT + 2, VERT_MARGIN + 2)
 	-- Draw the scrollbar length
-	for i = 1, 17 do
+	for i = 1, isHorizontal() and 17 or 31 do
 		scrollbarSection:draw(LEFT, VERT_MARGIN + scrollbarButton.height + (i - 1) * scrollbarSection.height)
 	end
 	-- Draw the bottom arrow

--- a/source/main.lua
+++ b/source/main.lua
@@ -1367,14 +1367,35 @@ function playdate.cranked(change, acceleratedChange)
 	end
 end
 
+function up()
+	if not menuActive then
+		directionHeld = 1
+	end
+end
+function down()
+	if not menuActive then
+		directionHeld = -1
+	end
+end
+function right()
+	if scene == READER then
+		directionHeld = -6
+	end
+end
+function left()
+	if scene == READER then
+		directionHeld = 6
+	end
+end
+
 function playdate.upButtonDown()
-	-- print("up")
 	if scene == LIBRARY then
 		offset = offset + BOOK_OFFSET_SIZE
 	else
-		if not menuActive then
-			directionHeld = 1
-		end
+		if readingOrientation == 1 then up()
+		elseif readingOrientation == 2 then left()
+		elseif readingOrientation == 3 then right()
+		elseif readingOrientation == 4 then down() end
 	end
 end
 
@@ -1383,13 +1404,13 @@ function playdate.upButtonUp()
 end
 
 function playdate.downButtonDown()
-	-- print("down")
 	if scene == LIBRARY then
 		offset = offset - BOOK_OFFSET_SIZE
 	else
-		if not menuActive then
-			directionHeld = -1
-		end
+		if readingOrientation == 1 then down()
+		elseif readingOrientation == 2 then right()
+		elseif readingOrientation == 3 then left()
+		elseif readingOrientation == 4 then up() end
 	end
 end
 
@@ -1398,9 +1419,11 @@ function playdate.downButtonUp()
 end
 
 function playdate.leftButtonDown()
-	-- print("left")
 	if scene == READER then
-		directionHeld = 6
+		if readingOrientation == 1 then left()
+		elseif readingOrientation == 2 then down()
+		elseif readingOrientation == 3 then up()
+		elseif readingOrientation == 4 then right() end
 	end
 end
 
@@ -1409,9 +1432,11 @@ function playdate.leftButtonUp()
 end
 
 function playdate.rightButtonDown()
-	-- print("right")
 	if scene == READER then
-		directionHeld = -6
+		if readingOrientation == 1 then right()
+		elseif readingOrientation == 2 then up()
+		elseif readingOrientation == 3 then down()
+		elseif readingOrientation == 4 then left() end
 	end
 end
 

--- a/source/main.lua
+++ b/source/main.lua
@@ -993,7 +993,7 @@ function playdate.update()
 		drawLibrary()
 	elseif scene == READER then
 		-- Update offset when the D-pad is held
-		offset = offset + directionHeld * BTN_SCROLL_SPEED
+		offset = offset + directionHeld * BTN_SCROLL_SPEED * delta
 		if menuActive or not playScrollSound then
 			sound:setVolume(0)
 		else

--- a/source/main.lua
+++ b/source/main.lua
@@ -80,6 +80,7 @@ local DEFAULT_BOOKS <const> = {
 	"Frankenstein.txt",
 	"The Great Gatsby.txt",
 }
+local readingOrientation = 1
 
 -- Shared
 -- The current scene being displayed
@@ -294,6 +295,21 @@ local MENU_OPTIONS <const> = {
 			end
 		end
 	},
+	{
+		label = "Orientation",
+		options =  {
+			"Horizontal",
+			"Vertical (Left)",
+			"Vertical (Right)",
+			"Upside Down"
+		},
+		initialValue = function ()
+			return readingOrientation
+		end,
+		callback = function (index)
+			readingOrientation = index
+		end
+	},
 }
 
 -- Generate the options for the reader font menu
@@ -350,6 +366,7 @@ local saveState = function ()
 	state.progressIndicator = progressIndicator
 	state.playScrollSound = playScrollSound
 	state.showDefaultBooks = showDefaultBooks
+	state.readingOrientation = readingOrientation
 	playdate.datastore.write(state)
 	print("State saved!")
 	-- print("State saved: " .. json.encode(state))
@@ -372,6 +389,7 @@ local loadState = function ()
 	setProgressIndicator(getOrDefault(state, "progressIndicator", "number", progressIndicator))
 	playScrollSound = getOrDefault(state, "playScrollSound", "boolean", playScrollSound)
 	showDefaultBooks = getOrDefault(state, "showDefaultBooks", "boolean", showDefaultBooks)
+	readingOrientation = getOrDefault(state, "readingOrientation", "number", readingOrientation)
 end
 
 local loadCurrentBookSettings = function ()


### PR DESCRIPTION
Adds a new "Orientation" option to the settings that allows you to choose the layout of the text, rotating the entire screen, potentially useful if you'd like to hold your playdate in a different way.

Does not affect the main menu or the options page.

The rotation operation is super slow so I made the scroll use deltaTime rather than scrolling a set amount each frame.
If you don't want to merge this PR on account of it running really slowly, that's fine, this was mostly for personal use and I don't intend to try to optimise it. If you do, this is best paired with #12 so that the expensive rotations aren't being processed every frame.

<img width="418" height="261" alt="image" src="https://github.com/user-attachments/assets/35a2dd3b-a1cf-4b0a-8067-05f7f2f6dc16" />
<img width="426" height="265" alt="image" src="https://github.com/user-attachments/assets/10bf8918-203f-467f-b6c1-ef5df6411f91" />
